### PR TITLE
fix: 排除 vendor/flybay/InstitutionCard.tsx 修复类型检查

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "vendor/flybay/src/app",
     "vendor/flybay/src/lib",
     "vendor/flybay/src/components/HomeInstitutionCard.tsx",
+    "vendor/flybay/src/components/InstitutionCard.tsx",
     "vendor/flybay/src/components/PosterButton.tsx",
     "vendor/flybay/src/components/detail"
   ]


### PR DESCRIPTION
## Summary

- flybay 子模块新增的 `InstitutionCard.tsx` 内部 `import "@/lib/institutions"`，该路径在主项目下解析不到，导致 `next build` 类型检查失败
- 主项目并未引用此组件，按既有约定（同 `HomeInstitutionCard.tsx`）加入 `tsconfig.json` 的 `exclude` 列表

## Test plan

- [x] 本地 `npm run build` 通过（TypeScript 检查 + 静态导出）
- [ ] CI 构建通过（`com` / `cn` 双变体）